### PR TITLE
Optionally pass Twig_Environment and JsonSchema\Validator to Factory

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,7 +2,6 @@
 
 namespace Clue\Confgen;
 
-use Twig_Loader_String;
 use Twig_Environment;
 use JsonSchema\Validator;
 
@@ -10,13 +9,7 @@ class Factory
 {
     public function createConfgen()
     {
-        // documentation explicitly warns against using this loader because it
-        // will be removed with Twig v2.0 eventually.
-        // However, it exactly implements our use case because template contents
-        // are always held in memory.
-        $loader = new Twig_Loader_String();
-
-        $twig = new Twig_Environment($loader);
+        $twig = new Twig_Environment();
         $twig->enableStrictVariables();
 
         $validator = new Validator();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -7,13 +7,46 @@ use JsonSchema\Validator;
 
 class Factory
 {
-    public function createConfgen()
+    private $twig;
+    private $validator;
+
+    /**
+     * instantiate new Factory, used to create a `Confgen` instance
+     *
+     * Optionally, you can explicitly pass an instance of `Twig_Environment` to
+     * this constructor. If nothing is passed, it will initialize sane defaults.
+     * You may want to pass an instance if you want to use of the following:
+     * - custom twig extensions
+     * - custom twig functions
+     * - custom twig filters
+     *
+     * Please note that the given `Twig_Environment` instance is mutable.
+     * We will automatically assign a new loader and forcefully enable strict
+     * variables, no matter what was previously set.
+     *
+     * Optionally, you can explicitly pass an instance of `JsonSchema\Validator` to
+     * this constructor. If nothing is passed, it will initialize sane defaults.
+     *
+     * @param Twig_Environment|null $twig      (optional) Twig_Environment to use
+     * @param Validator|null        $validator (optional) JsonSchema\Validator to use
+     */
+    public function __construct(Twig_Environment $twig = null, Validator $validator = null)
     {
-        $twig = new Twig_Environment();
+        if ($twig === null) {
+            $twig = new Twig_Environment();
+        }
+        if ($validator === null) {
+            $validator = new Validator();
+        }
+
         $twig->enableStrictVariables();
 
-        $validator = new Validator();
+        $this->twig = $twig;
+        $this->validator = $validator;
+    }
 
-        return new Confgen($twig, $validator);
+    public function createConfgen()
+    {
+        return new Confgen($this->twig, $this->validator);
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -11,4 +11,15 @@ class FactoryTest extends TestCase
 
         $this->assertInstanceOf('Clue\Confgen\Confgen', $confgen);
     }
+
+    public function testFactoryPassesTwigEnvironmentToConfgen()
+    {
+        $twig = new Twig_Environment();
+        $factory = new Factory($twig);
+        $confgen = $factory->createConfgen();
+
+        $property = new \ReflectionProperty($confgen, 'twig');
+        $property->setAccessible(true);
+        $this->assertSame($twig, $property->getValue($confgen));
+    }
 }


### PR DESCRIPTION
This allows you to use a custom `Twig_Environment` instance, such as one that has custom extensions, functions or filters.

Refs #2, #4, #5.
