### PR TITLE
Lock Travis distro so new defaults will not break the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: php
+dist: trusty
+
 php:
-  - 5.3
   - 5.6
   - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: hhvm
+
 install:
   - composer install --prefer-source --no-interaction
+
 script:
   - phpunit --coverage-text


### PR DESCRIPTION
Travis removed support for some older versions of PHP (travis-ci/travis-ci#7163). These versions are still supported by this project, so we now have to explicitly define the base distro to test against