### PR TITLE
As in previous version when command execution failed an exception should be thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,9 @@ generate a output (configuration) file from the given [template file](#templates
 $confgen->processTemplate('template.twig', 'data.json');
 ```
 
+The `processTemplate($templateFile, $dataFile)` method throws a `RuntimeException` when a `reload` command fail.
+See also [Meta variables](#meta-variables) section for more details on `reload`.
+
 See also [templates section](#templates) above for more details on the
 The [input data](#input-data).
 
@@ -288,6 +291,9 @@ generate any number of output (configuration) files from the given [configuratio
 ```php
 $confgen->processDefinition('confgen.json', 'data.json');
 ```
+
+The `processDefinition($definitionFile, $dataFile)` method throws a `RuntimeException` when a `reload` command fail.
+See also [Meta variables](#meta-variables) section for more details on `reload`.
 
 See also [configuration section](#configuration) above for more details.
 

--- a/src/Confgen.php
+++ b/src/Confgen.php
@@ -103,7 +103,10 @@ class Confgen
 
         // let's reload all the files after (successfully) writing all of them
         foreach ($commands as $command) {
-            $this->executor->executeCommand($command);
+            $code = $this->executor->executeCommand($command);
+            if ($code !== 0) {
+                throw new \RuntimeException('Unable to execute "' . $command . '"', $code);
+            }
         }
     }
 

--- a/tests/BinTest.php
+++ b/tests/BinTest.php
@@ -86,4 +86,14 @@ class BinTest extends TestCase
         $this->assertFileExists('ShouldNotExist');
         unlink('ShouldNotExist');
     }
+
+    public function test18ErrorIfCommandExecutionFailed()
+    {
+        chdir(__DIR__ . '/fixtures/18-command-execution-failed');
+
+        exec(escapeshellarg(__DIR__ . '/../bin/confgen') . ' -t template.twig 2>&1', $out, $code);
+
+        $this->assertEquals(1, $code);
+        unlink('output');
+    }
 }

--- a/tests/ConfgenTest.php
+++ b/tests/ConfgenTest.php
@@ -247,4 +247,19 @@ class ConfgenTest extends TestCase
         // reload command is skipped due to no-scripts flag
         $this->assertFileNotExists('ShouldNotExist');
     }
+
+    public function test18CommandExecutionFailed()
+    {
+        chdir(__DIR__ . '/fixtures/18-command-execution-failed');
+
+        // Must catch it manually due to fact that unlink is not executed when testing for exception
+        try {
+            $this->confgen->processTemplate('template.twig', null);
+        } catch (RuntimeException $e) {
+            $this->assertTrue(true);
+            unlink('output');
+            return;
+        }
+        $this->fail('RuntimeException not thrown');
+    }
 }

--- a/tests/fixtures/18-command-execution-failed/template.twig
+++ b/tests/fixtures/18-command-execution-failed/template.twig
@@ -1,0 +1,5 @@
+---
+target: output
+reload: "echo hey && false"
+---
+Content


### PR DESCRIPTION
In the previous versions of confgen the command execution throws an exception. This should be implemented again to improve error handling.